### PR TITLE
build: update commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   commitlint:
-    uses: edx/.github/.github/workflows/commitlint.yml@master
+    uses: openedx/.github/.github/workflows/commitlint.yml@master


### PR DESCRIPTION
## Description
- The commitlint reusable workflow hosted in `edx/.github` path is not being maintained and most of the edX repos are [using](https://github.com/search?q=org%3Aedx%20edx%2F.github%2F.github%2Fworkflows%2Fcommitlint.yml%40master&type=code) the `openedx/.github` version of the workflow instead. 
- Updated the path to use the public reusable workflow for commit lint check on the PR. 